### PR TITLE
release 0.1.2

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -65,7 +65,7 @@ export function route<ParseParam = null, ParseQuery = null, Hash extends string[
 
   function parseQuery(
     query: Record<string, string | string[] | undefined>,
-  ): ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] } {
+  ): ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] | undefined } {
     const decodeQuery = convertToDecodeString(query, { decode: true });
     const keyList = (typeQuery && Object.keys(typeQuery)) || [];
 
@@ -101,7 +101,7 @@ export function route<ParseParam = null, ParseQuery = null, Hash extends string[
     location: Location,
   ): {
     param: ParseParam extends null ? Record<string, never> : { [P in keyof ParseParam]: ParseParam[P] };
-    query: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] };
+    query: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] | undefined };
     hash: [...Hash][number];
     state: ParseState extends null ? Record<string, never> : { [P in keyof ParseState]: ParseState[P] };
   };
@@ -110,7 +110,7 @@ export function route<ParseParam = null, ParseQuery = null, Hash extends string[
     location?: Location,
   ): {
     param: ParseParam extends null ? Record<string, never> : { [P in keyof ParseParam]: ParseParam[P] };
-    query?: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] };
+    query?: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] | undefined };
     hash?: [...Hash][number];
     state?: ParseState extends null ? Record<string, never> : { [P in keyof ParseState]: ParseState[P] };
   };
@@ -119,7 +119,7 @@ export function route<ParseParam = null, ParseQuery = null, Hash extends string[
     location?: Location,
   ): {
     param: ParseParam extends null ? Record<string, never> : { [P in keyof ParseParam]: ParseParam[P] };
-    query?: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] };
+    query?: ParseQuery extends null ? Record<string, never> : { [P in keyof ParseQuery]: ParseQuery[P] | undefined };
     hash?: [...Hash][number];
     state?: ParseState extends null ? Record<string, never> : { [P in keyof ParseState]: ParseState[P] };
   } {

--- a/src/route.ts
+++ b/src/route.ts
@@ -31,8 +31,8 @@ export function build<Param = null, Query = null, Hash extends string | undefine
   return ({ param, query, hash, state }: { param?: Param; query?: Query; hash?: Hash; state?: State }) => {
     return {
       pathname: param ? `${urlParamReplace(path, convertToString(param, { encode: true }))}` : path,
-      search: query ? `?${urlQueryReplace(convertToString(query))}` : undefined,
-      hash: hash || undefined,
+      search: query ? `?${urlQueryReplace(convertToString(query))}` : '',
+      hash: hash || '',
       state: state || null,
     };
   };

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -42,14 +42,14 @@ it('[build func.] typeParser optional, required type check', () => {
 
   expect(product.build({ param: { id: 1 } })).toEqual({
     pathname: '/id/1',
-    search: undefined,
-    hash: undefined,
+    search: '',
+    hash: '',
     state: null,
   });
   expect(product.build({ param: { id: 1 }, query: { page: 1, sort: 'L' } })).toEqual({
     pathname: '/id/1',
     search: '?page=1&sort=L',
-    hash: undefined,
+    hash: '',
     state: null,
   });
   expect(product.build({ param: { id: 1 }, query: { page: 1 }, hash: '#ss' })).toEqual({
@@ -124,7 +124,7 @@ it('[build func.] oneOf union type check', () => {
   expect(product.build({ query: { sort: 'L' } })).toEqual({
     pathname: '/id',
     search: '?sort=L',
-    hash: undefined,
+    hash: '',
     state: null,
   });
 });
@@ -160,25 +160,25 @@ it('[build func.] arrayOf return build value check, that using urlQueryReplace f
   expect(product.build({ query: { string: ['1', '2'] } })).toEqual({
     pathname: '/id',
     search: '?string=1&string=2',
-    hash: undefined,
+    hash: '',
     state: null,
   });
   expect(product.build({ query: { number: [1, 2] } })).toEqual({
     pathname: '/id',
     search: '?number=1&number=2',
-    hash: undefined,
+    hash: '',
     state: null,
   });
   expect(product.build({ query: { boolean: [true, false] } })).toEqual({
     pathname: '/id',
     search: '?boolean=true&boolean=false',
-    hash: undefined,
+    hash: '',
     state: null,
   });
   expect(product.build({ query: { date: [new Date('2022-01-13'), new Date('2022-03-13')] } })).toEqual({
     pathname: '/id',
     search: '?date=2022-01-13T00%3A00%3A00.000Z&date=2022-03-13T00%3A00%3A00.000Z',
-    hash: undefined,
+    hash: '',
     state: null,
   });
 });

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -365,3 +365,36 @@ it('[parse func.] string type convert to Date type', () => {
   expect(product.parseQuery({ startDate: '2022-03-01' })).not.toEqual({ startDate: '2022-03-01' });
   expect(product.parseQuery({ startDate: '2022-03-01' })).toEqual({ startDate: new Date('2022-03-01') });
 });
+
+it('[parse func] query what required value in build func. can return undefined in case using url website', () => {
+  const product = route({
+    path: '/id/:id',
+    typeParam: {
+      id: typeParser.number.required,
+    },
+    typeQuery: {
+      page: typeParser.number.required,
+    },
+  });
+
+  expect(
+    product.parse(
+      { id: '2' },
+      {
+        pathname: '/id/2',
+        search: '',
+        hash: '',
+        state: null,
+      },
+    ),
+  ).toEqual({
+    param: {
+      id: 2,
+    },
+    query: {
+      page: undefined,
+    },
+    hash: '',
+    state: {},
+  });
+});


### PR DESCRIPTION
# Release

- [utils]: query can return undefined (build typeQuery what required config)
- [utils]: build search, hash default return => ''
  - prev undefined
