### PR TITLE
release 0.2.7

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,7 @@ module.exports = {
   settings: {
     // https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file#importextensions
     // This defaults to ['.js'], unless you are using the react shared config, in which case it is specified as ['.js', '.jsx']. Despite the default, if you are using TypeScript (without the plugin:import/typescript config described above) you must specify the new extensions (.ts, and also .tsx if using React).
-    'import/extensions': ['.js','.ts', ],
+    'import/extensions': ['.js', '.ts'],
     'import/parsers': {
       // https://github.com/import-js/eslint-plugin-import?tab=readme-ov-file#importparsers
       // This is useful if you're interop-ing with TypeScript directly using webpack
@@ -98,4 +98,5 @@ module.exports = {
     ],
     'prettier/prettier': ['error'],
   },
+  ignorePatterns: ['jest.config.js'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
-module.exports = {
+/** @type {import('jest').Config} */ 
+const config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
 };
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-type-safe",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "route type safe for page location with pathname, query, hash, state",
   "keywords": [
     "route",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -111,3 +111,21 @@ export function urlQueryReplace(init: URLSearchParamsInit = ''): URLSearchParams
         }, [] as ParamKeyValuePair[]),
   );
 }
+
+export function searchParamsToObj(searchParams: URLSearchParams): {
+  [k: string]: string | string[];
+} {
+  const obj: {
+    [k: string]: string | string[];
+  } = {};
+
+  for (const [key, value] of searchParams) {
+    if (obj[key] !== undefined) {
+      obj[key] = Array.isArray(obj[key]) ? [...obj[key], value] : [obj[key] as string, value];
+    } else {
+      obj[key] = value;
+    }
+  }
+
+  return obj;
+}

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,7 +1,7 @@
 import { Location } from 'history';
 
 import { SubPartial } from './global';
-import { convertToString, convertToDecodeString, urlQueryReplace, urlParamReplace } from './helpers';
+import { convertToString, convertToDecodeString, urlQueryReplace, urlParamReplace, searchParamsToObj } from './helpers';
 
 type UseType = string | number | boolean | Date;
 
@@ -161,7 +161,7 @@ export function route<ParseParam = null, ParseQuery = null, Hash extends string[
     state?: ParseState extends null ? Record<string, never> : { [P in keyof ParseState]: ParseState[P] };
   } {
     const searchParams = urlQueryReplace(location?.search);
-    const query = Object.fromEntries([...searchParams]);
+    const query = searchParamsToObj(searchParams);
 
     return {
       param: parseParam(param),

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -163,8 +163,11 @@ it('[parse func.] If value is not array type in arrayOf parse, return new array'
     },
   });
 
+  expect(product.parseQuery({ string: ['22', '33'] })).toEqual({ string: ['22', '33'] });
   expect(product.parseQuery({ string: '22' })).toEqual({ string: ['22'] });
+  expect(product.parseQuery({ number: ['22', '33'] })).toEqual({ number: [22, 33] });
   expect(product.parseQuery({ number: '22' })).toEqual({ number: [22] });
+  expect(product.parseQuery({ boolean: ['true', 'false'] })).toEqual({ boolean: [true, false] });
   expect(product.parseQuery({ boolean: 'true' })).toEqual({ boolean: [true] });
   expect(product.parseQuery({ date: '2022-01-13T00%3A00%3A00.000Z' })).toEqual({ date: [new Date('2022-01-13')] });
 });


### PR DESCRIPTION
- \[config]: eslint
  - jset.config.js ignore
  - jest.config.js
    - type 적용

- \[util]: searchParamsToObj
  - querystirng을 object 변환시 데이터가 업데이트 되어 누락 발생된 이슈 해결
    - querystring이 중복된 키가 있을 경우 배열로 합치기